### PR TITLE
With BTF, tcpconnect.bt does not need libc headers installed

### DIFF
--- a/tools/tcpaccept.bt
+++ b/tools/tcpaccept.bt
@@ -20,7 +20,13 @@
 #include <linux/socket.h>
 #include <net/sock.h>
 #else
-#include <sys/socket.h>
+/*
+ * With BTF providing types, socket headers are not needed.
+ * We only need to supply the preprocessor defines in this script.
+ * AF_INET/AF_INET6 are part of the stable arch-independent Linux ABI
+ */
+#define AF_INET   2
+#define AF_INET6 10
 #endif
 
 BEGIN

--- a/tools/tcpconnect.bt
+++ b/tools/tcpconnect.bt
@@ -23,10 +23,12 @@
 #include <net/sock.h>
 #else
 /*
- * Note: you may need to install the glibc-headers package or other package
- * containing sys/socket.h, which contains the AF_INET and AF_INET6 macros
+ * BTF provides the types, we just need to define AF_INET and AF_INET6.
+ * These are Linux ABI defines, and are not architecture-specific.
+ * With BTF, this allows tcpconnect.bt to work without glibc headers:
  */
-#include <sys/socket.h>
+#define AF_INET   2 /* IPv4 */
+#define AF_INET6 10 /* IPv6 */
 #endif
 
 BEGIN

--- a/tools/tcpdrop.bt
+++ b/tools/tcpdrop.bt
@@ -24,7 +24,13 @@
 #include <linux/socket.h>
 #include <net/sock.h>
 #else
-#include <sys/socket.h>
+/*
+ * With BTF providing types, socket headers are not needed.
+ * We only need to supply the preprocessor defines in this script.
+ * AF_INET/AF_INET6 are part of the stable arch-independent Linux ABI
+ */
+#define AF_INET   2
+#define AF_INET6 10
 #endif
 
 BEGIN

--- a/tools/tcplife.bt
+++ b/tools/tcplife.bt
@@ -19,7 +19,13 @@
 #include <linux/socket.h>
 #include <linux/tcp.h>
 #else
-#include <sys/socket.h>
+/*
+ * With BTF providing types, socket headers are not needed.
+ * We only need to supply the preprocessor defines in this script.
+ * AF_INET/AF_INET6 are part of the stable arch-independent Linux ABI
+ */
+#define AF_INET   2
+#define AF_INET6 10
 #endif
 
 BEGIN

--- a/tools/tcpretrans.bt
+++ b/tools/tcpretrans.bt
@@ -21,7 +21,13 @@
 #include <linux/socket.h>
 #include <net/sock.h>
 #else
-#include <sys/socket.h>
+/*
+ * With BTF providing types, socket headers are not needed.
+ * We only need to supply the preprocessor defines in this script.
+ * AF_INET/AF_INET6 are part of the stable arch-independent Linux ABI
+ */
+#define AF_INET   2
+#define AF_INET6 10
 #endif
 
 BEGIN


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
